### PR TITLE
Fix default campfire intensity and sound playback

### DIFF
--- a/lua/entities/lp_campfire/cl_init.lua
+++ b/lua/entities/lp_campfire/cl_init.lua
@@ -18,11 +18,7 @@ function ENT:Think()
             local dist = ply:GetPos():Distance(self:GetPos())
             local maxDist = 600
             local vol = math.Clamp(1 - dist / maxDist, 0, 1) * self:GetIntensity()
-            if vol <= 0 then
-                self.FireSound:Stop()
-            else
-                self.FireSound:ChangeVolume(vol, 0)
-            end
+            self.FireSound:ChangeVolume(vol, 0)
         end
         local dlight = DynamicLight(self:EntIndex())
         if dlight then

--- a/lua/entities/lp_campfire/init.lua
+++ b/lua/entities/lp_campfire/init.lua
@@ -16,7 +16,7 @@ function ENT:Initialize()
     if IsValid(phys) then phys:Wake() end
 
     self:SetFireEnabled(false)
-    self:SetIntensity(1)
+    self:SetIntensity(0.5)
     self:SetSoundName("fire1")
 
     self.UsePlayers = {}
@@ -62,7 +62,7 @@ function ENT:StartFire()
     local fire = ents.Create("env_fire")
     if not IsValid(fire) then return end
     fire:SetPos(self:GetPos() + Vector(0,0,10))
-    fire:SetKeyValue("firesize", tostring(math.Clamp(64 * self:GetIntensity(), 32, 128)))
+    fire:SetKeyValue("firesize", tostring(math.Clamp(64 * self:GetIntensity(), 0, 128)))
     fire:SetKeyValue("fireattack", "4")
     fire:SetKeyValue("health", "10")
     fire:SetKeyValue("damagescale", "0")


### PR DESCRIPTION
## Summary
- lower initial flame intensity and allow smaller `env_fire` sizes
- prevent campfire loop from stopping so it resumes when player approaches

## Testing
- `luac -p lua/entities/lp_campfire/init.lua lua/entities/lp_campfire/cl_init.lua lua/entities/lp_campfire/shared.lua`

------
https://chatgpt.com/codex/tasks/task_e_68b331f779448328bbed36dd96cd8eec