### PR TITLE
Fix long E press not opening campfire menu

### DIFF
--- a/lua/entities/lp_campfire/init.lua
+++ b/lua/entities/lp_campfire/init.lua
@@ -24,7 +24,7 @@ end
 
 function ENT:Use(activator)
     if not activator:IsPlayer() then return end
-    self.UsePlayers[activator] = CurTime()
+    self.UsePlayers[activator] = self.UsePlayers[activator] or CurTime()
 end
 
 function ENT:Think()


### PR DESCRIPTION
## Summary
- prevent repeated `Use` calls from resetting the hold timer so a long E press opens the campfire UI

## Testing
- `luac -p lua/entities/lp_campfire/init.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b334db5b248328a9999cf938115cf2