### PR TITLE
Use MP3 files for campfire sounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Установка
 
 1. Скопируйте папку с аддоном в `garrysmod/addons/`.
-2. Поместите звуковые файлы `fire1.wav`, `fire2.wav`, `fire3.wav` в
+2. Поместите звуковые файлы `fire1.mp3`, `fire2.mp3`, `fire3.mp3` в
    `sound/lonepine_campfire/` внутри аддона.
 3. Запустите игру и найдите сущность **LonePine Campfire** во вкладке `Entities > Server`.
 

--- a/lua/entities/lp_campfire/cl_init.lua
+++ b/lua/entities/lp_campfire/cl_init.lua
@@ -10,7 +10,7 @@ function ENT:Think()
         if not self.FireSound or self.CurrentSound ~= self:GetSoundName() then
             if self.FireSound then self.FireSound:Stop() end
             self.CurrentSound = self:GetSoundName()
-            self.FireSound = CreateSound(self, SOUND_PATH .. self.CurrentSound .. ".wav")
+            self.FireSound = CreateSound(self, SOUND_PATH .. self.CurrentSound .. ".mp3")
             self.FireSound:PlayEx(0, 100)
         end
         if self.FireSound then

--- a/lua/entities/lp_campfire/init.lua
+++ b/lua/entities/lp_campfire/init.lua
@@ -6,9 +6,9 @@ include("shared.lua")
 util.AddNetworkString("lp_campfire_open")
 util.AddNetworkString("lp_campfire_update")
 
-resource.AddSingleFile("sound/lonepine_campfire/fire1.wav")
-resource.AddSingleFile("sound/lonepine_campfire/fire2.wav")
-resource.AddSingleFile("sound/lonepine_campfire/fire3.wav")
+resource.AddSingleFile("sound/lonepine_campfire/fire1.mp3")
+resource.AddSingleFile("sound/lonepine_campfire/fire2.mp3")
+resource.AddSingleFile("sound/lonepine_campfire/fire3.mp3")
 
 function ENT:Initialize()
     self:SetModel("models/props_unique/firepit_campground.mdl")


### PR DESCRIPTION
## Summary
- Use MP3 files instead of WAV for campfire audio resources
- Update client sound creation to load .mp3 files
- Adjust documentation to instruct placing MP3 files

## Testing
- `find lua -name '*.lua' -print0 | xargs -0 -n1 luac -p`

------
https://chatgpt.com/codex/tasks/task_e_68b33cf75f408328b97ce4546d3d9571